### PR TITLE
Add support to run apps as a Windows service

### DIFF
--- a/cmd/pqs/main.go
+++ b/cmd/pqs/main.go
@@ -15,10 +15,10 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/golang/protobuf/jsonpb"
+	_ "github.com/kardianos/minwinsvc" // import minwinsvc for windows service support
 	"github.com/pkg/errors"
 	"github.com/tmc/pqstream/ctxutil"
 	"github.com/tmc/pqstream/pqs"
-	// import minwinsvc for windows service support
 )
 
 var (

--- a/cmd/pqs/main.go
+++ b/cmd/pqs/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tmc/pqstream/ctxutil"
 	"github.com/tmc/pqstream/pqs"
+	// import minwinsvc for windows service support
 )
 
 var (

--- a/cmd/pqsd/main.go
+++ b/cmd/pqsd/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/tmc/pqstream"
 	"github.com/tmc/pqstream/ctxutil"
 	"github.com/tmc/pqstream/pqs"
+
+	_ "github.com/kardianos/minwinsvc" // import minwinsvc for windows service support
 )
 
 var (


### PR DESCRIPTION
I have found https://github.com/kardianos/minwinsvc to have the best and simplest way to add support to run apps as a Windows service

Fixes https://github.com/tmc/pqstream/issues/47

Should this be mentioned in the docs?