### PR TITLE
Add pylint to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,16 @@ jobs:
 
       - run: ./lint
 
+  python:
+    docker:
+      - image: circleci/python:3
+    steps:
+      - checkout
+
+      - run: sudo pip install pylint grpcio protobuf
+
+      - run: pylint clients/python/example.py
+
   docker-image:
     docker:
       - image: gcr.io/cloud-builders/docker
@@ -81,3 +91,4 @@ workflows:
       - build-and-test
       - lint
       - docker-image
+      - python


### PR DESCRIPTION
This adds a `pylint` stage to the circle buildjobs, that will lint the file `clients/python/example.py` using pylints default configuration.

This relates to #63, covering the lint part.