### PR TITLE
clients/python: make python example more verbose

### DIFF
--- a/clients/python/example.py
+++ b/clients/python/example.py
@@ -23,6 +23,8 @@ def run(messages):
     i = 0
     for event in stub.Listen(request):
         print("Received change, payload follows:")
+        print("OP: {0}".format(event.op))
+        print("Table: {0}.{1}".format(event.schema, event.table))
         print(event.payload)
         i = i + 1
         if i >= messages:


### PR DESCRIPTION
Make the python example a little more verbose