### PR TITLE
Move redaction decoding

### DIFF
--- a/cmd/pqsd/main.go
+++ b/cmd/pqsd/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -73,8 +72,8 @@ func run(ctx context.Context) error {
 	}
 
 	if (len(*redactions)) > 0 {
-		rfields := make(pqstream.FieldRedactions)
-		if err = json.NewDecoder(strings.NewReader(*redactions)).Decode(&rfields); err != nil {
+		rfields, err := pqstream.DecodeRedactions(*redactions)
+		if err != nil {
 			return errors.Wrap(err, "decoding redactions")
 		}
 

--- a/redactions.go
+++ b/redactions.go
@@ -1,10 +1,25 @@
 package pqstream
 
-import "github.com/tmc/pqstream/pqs"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tmc/pqstream/pqs"
+)
 
 // FieldRedactions describes how redaction fields are specified.
 // Top level map key is the schema, inner map key is the table and slice is the fields to redact.
 type FieldRedactions map[string]map[string][]string
+
+// DecodeRedactions returns a FieldRedactions map decoded from redactions specified in json format.
+func DecodeRedactions(r string) (FieldRedactions, error) {
+	rfields := make(FieldRedactions)
+	if err := json.NewDecoder(strings.NewReader(r)).Decode(&rfields); err != nil {
+		return nil, err
+	}
+
+	return rfields, nil
+}
 
 // WithFieldRedactions controls which fields are redacted from the feed.
 func WithFieldRedactions(r FieldRedactions) ServerOption {

--- a/redactions_test.go
+++ b/redactions_test.go
@@ -112,3 +112,41 @@ func TestServer_redactFields(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeRedactions(t *testing.T) {
+	type args struct {
+		r string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    FieldRedactions
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			args: args{r: `{"public":{"users":["first_name","last_name","email"]}}`},
+			want: FieldRedactions{
+				"public": {"users": []string{
+					"first_name",
+					"last_name",
+					"email",
+				},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeRedactions(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DecodeRedactions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("DecodeRedactions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I'm moving the decoding of redactions specified in json format to a package function for 2 reasons:
- If pqstream is used as a library one can send redactions in JSON as well
- Clean up pqsd.main