### PR TITLE
remove duplicated checks

### DIFF
--- a/lint
+++ b/lint
@@ -13,7 +13,6 @@ gometalinter -t --vendored-linters --cyclo-over=15 --deadline=2m --disable-all \
   --enable=deadcode \
   --enable=gocyclo \
   --enable=golint \
-  --enable=varcheck \
   --enable=structcheck \
   --enable=aligncheck \
   --enable=megacheck \

--- a/lint
+++ b/lint
@@ -10,7 +10,6 @@ gometalinter -t --vendored-linters --cyclo-over=15 --deadline=2m --disable-all \
   --enable=vet \
   --enable=vetshadow \
   --enable=gotype \
-  --enable=deadcode \
   --enable=gocyclo \
   --enable=golint \
   --enable=structcheck \

--- a/lint
+++ b/lint
@@ -12,7 +12,6 @@ gometalinter -t --vendored-linters --cyclo-over=15 --deadline=2m --disable-all \
   --enable=gotype \
   --enable=gocyclo \
   --enable=golint \
-  --enable=structcheck \
   --enable=aligncheck \
   --enable=megacheck \
   --enable=dupl \


### PR DESCRIPTION
In #56 it's been said that the CI checks performance should be better for the time that It takes, so I checked all linters and removed possible duplicates, this way we should get a lower time in CI.